### PR TITLE
Fix issue ironhack-edu/web-bootcamp#170

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -5,7 +5,7 @@ const mongoose = require("mongoose");
 // ℹ️ Sets the MongoDB URI for our app to have access to it.
 // If no env has been set, we dynamically set it to whatever the folder name was upon the creation of the app
 
-const MONGO_URI = process.env.MONGODB_URI || "mongodb://localhost/lab-express-basic-auth";
+const MONGO_URI = process.env.MONGODB_URI || "mongodb://127.0.0.1:27017/lab-express-basic-auth";
 
 mongoose
   .connect(MONGO_URI)


### PR DESCRIPTION
Use `127.0.0.1` instead of `localhost` for Mongoose DB connection

Solves issue: https://github.com/ironhack-edu/web-bootcamp/pull/171